### PR TITLE
added support for camera live streams

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -235,7 +235,9 @@ impl ParserBuilder {
     {
         let boundary = {
             let mut line = Vec::with_capacity(boundary.len() + 4);
-            line.extend_from_slice(b"--");
+            if !boundary.starts_with("--") {
+                line.extend_from_slice(b"--");
+            }
             line.extend_from_slice(boundary.as_bytes());
             line.extend_from_slice(b"\r\n");
             line
@@ -344,6 +346,7 @@ mod tests {
             parts.pop().unwrap().unwrap_err();
         };
         tester("boundary", input.as_bytes(), verify_parts).await;
+        tester("--boundary", input.as_bytes(), verify_parts).await;
     }
 
     #[tokio::test]
@@ -354,6 +357,7 @@ mod tests {
             parts.pop().unwrap().unwrap_err();
         };
         tester("boundary", input.as_bytes(), verify_parts).await;
+        tester("--boundary", input.as_bytes(), verify_parts).await;
     }
 
     #[tokio::test]
@@ -414,6 +418,7 @@ mod tests {
             assert_eq!(i, 2);
         };
         tester("boundary", input.as_bytes(), verify_parts).await;
+        tester("--boundary", input.as_bytes(), verify_parts).await;
     }
 
     #[tokio::test]
@@ -461,6 +466,7 @@ mod tests {
             assert_eq!(i, 2);
         };
         tester("myboundary", input.as_bytes(), verify_parts).await;
+        tester("--myboundary", input.as_bytes(), verify_parts).await;
     }
 
     #[tokio::test]
@@ -485,5 +491,6 @@ mod tests {
             assert_eq!(i, 1);
         };
         tester("myboundary", input.as_bytes(), verify_parts).await;
+        tester("--myboundary", input.as_bytes(), verify_parts).await;
     }
 }


### PR DESCRIPTION
... with `--` prefix already in the boundary header

This solves the situation when response comes with something like this:
```
HTTP/1.1 200 OK
Content-type: multipart/x-mixed-replace; boundary=--myboundary
...
```

and then the individual frame contains

```
--myboundary
Content-Type: image/jpeg
Content-Length: 11493
...
```

When the `--` was added unconditionally, I got the message "bad boundary" because parser expected `----myboundary` because I passed the boundary exactly as I received it from the response header.